### PR TITLE
Feature/fix bullet styles and index links

### DIFF
--- a/app/assets/stylesheets/2015/base.css.scss
+++ b/app/assets/stylesheets/2015/base.css.scss
@@ -577,9 +577,17 @@ section.content {
 			}
 		}
 
+
 		ul {
+			list-style: disc;
+		}
+
+		ol {
+			list-style: decimal;
+		}
+
+		ul, ol {
 			li {
-				font-size: 14px;
 				line-height: 1.5em;
 			}
 		}

--- a/app/assets/stylesheets/2015/base.css.scss
+++ b/app/assets/stylesheets/2015/base.css.scss
@@ -145,6 +145,7 @@ footer {
 
 	.right {
 		float: right;
+		text-align: right;
 	}
 }
 
@@ -309,7 +310,7 @@ article {
 }
 
 .dark {
-	background-color:rgba(0, 0, 0, 0.5);
+	background-color:rgba(0, 0, 0, 0.6);
 
 	article {
 		p, h2 {
@@ -870,4 +871,20 @@ section.content {
 		padding:0 30px;
 	}
 	
+
+	footer {
+		padding: 0.5em 10px 0.5em 10px;
+		color: white;
+		font-size: 1.1em;
+		width: auto;
+
+		div {
+			margin-bottom: 5px;
+		}
+
+		.right {
+			float: none;
+			text-align: left;
+		}
+	}	
 }

--- a/app/assets/stylesheets/2015/base.css.scss
+++ b/app/assets/stylesheets/2015/base.css.scss
@@ -24,7 +24,6 @@ body {
 	font-family: Helvetica, Arial, sans-serif;
 	font-size: 12px;
 	background: white no-repeat bottom center;
-	padding-bottom: 80px;
 	@include image-url-2x("crystals.png")
 }
 
@@ -113,7 +112,7 @@ aside#ticketdrop {
 	}
 }
 
-header {
+header, footer {
 	display:block;
 	margin:0 auto;
 	width:100%;
@@ -135,6 +134,17 @@ header {
 		visibility:hidden;
 		display:block;
 		height:0;
+	}
+}
+
+footer {
+	padding-top: 1.0em;
+	padding-bottom: 1.0em;
+	color: white;
+	font-size: 1.1em;
+
+	.right {
+		float: right;
 	}
 }
 
@@ -325,13 +335,11 @@ article {
 			}
 
 		}
+	}
 
-		a {
-			color: black;
-			text-decoration: none;
-		}
-
-
+	a {
+		color: black;
+		text-decoration: none;
 	}
 }
 
@@ -633,7 +641,7 @@ section.content {
 
 
 @media only screen and (min-width:641px) and (max-width:1130px) {
-	header {
+	header, footer {
 		height: auto;
 		position:relative;
 		img {

--- a/app/views/index/index.html.haml
+++ b/app/views/index/index.html.haml
@@ -34,17 +34,6 @@
     - else
       %h2 The Program
       %p Whoa there, it's still early days yet! We'll be adding to and refining the program in 2014, so stay tuned for more details.
-/    %button{id: "showmore"}
-/      View program online
-/      = image_tag("tinyruby.png", alt: "Celebrating Swancon 40")
-/    %div{id: "more"}
-/      %div{class: "sq1"}
-/        %h4 TIME 1
-/        %p Details coming soon
-/    %p 
-/    &elipsis or 
-/    = link_to "download"
-/    the pdf.
 
 - unless viewable_events.empty?
   %article{id:"events"}
@@ -60,8 +49,6 @@
           %h3=item[:title]
           %h5=item[:date]
           %p=item[:text]
-  /        = link_to item[:path] do
-  /         =image_tag("ruby150-2.png", alt: item[:title])
 
 %section
   %article{id: "contact"}
@@ -74,13 +61,15 @@
         &dash; Kat Griffiths
         %br
         %strong Secretary
-        &dash; Stephen Griffiths
+        &dash; 
+        = link_to "Stephen Griffiths", "mailto:secretary-2015@swancon.com.au"
         %br
         %strong Treasurer
         &dash; Helen Duffill
         %br
-        %strong Panel Coordinator
-        &dash; Sarah Parker
+        %strong Head Programmer
+        &dash; 
+        = link_to "Sarah Parker", "mailto:programmer-2015@swancon.com.au"        
     %div 
       %p
         %strong Contact email:

--- a/app/views/layouts/2015.html.haml
+++ b/app/views/layouts/2015.html.haml
@@ -54,9 +54,13 @@
       %section{class:"dark"}
         %footer
           %div{class: "right"}
-            Swancon&trade; is a 
-            = link_to "WASFF", "http://wasff.sf.org.au"
-            project
+            %div
+              Swancon&trade; is a 
+              = link_to "WASFF", "http://wasff.sf.org.au"
+              project
+            %div
+              The Swancon 40 website and graphic design was provided by
+              = link_to "Skylark Creative", "http://skylarkcreative.net"
           %div
             If you encounter any errors with the website, please report them 
             = link_to "here", "http://goo.gl/forms/QhE9pCOaq6"

--- a/app/views/layouts/2015.html.haml
+++ b/app/views/layouts/2015.html.haml
@@ -51,3 +51,12 @@
               = render_clock
       
      
+      %section{class:"dark"}
+        %footer
+          %div{class: "right"}
+            Swancon&trade; is a 
+            = link_to "WASFF", "http://wasff.sf.org.au"
+            project
+          %div
+            If you encounter any errors with the website, please report them 
+            = link_to "here", "http://goo.gl/forms/QhE9pCOaq6"


### PR DESCRIPTION
Unordered and ordered lists didn't have styles, this has been rectified for CMS content (may need to check other parts of the site to ensure everything is okay)

Secretary and programmer now link to their email addresses.

All pages now have a footer containing info about WASFF and a link to the problem reporting page
