### PR TITLE
Feature/add inbound tracking

### DIFF
--- a/app/assets/javascripts/advertising_tags.js.coffee
+++ b/app/assets/javascripts/advertising_tags.js.coffee
@@ -1,0 +1,3 @@
+# Place all the behaviors and hooks related to the matching controller here.
+# All this logic will automatically be available in application.js.
+# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/stylesheets/advertising_tags.css.scss
+++ b/app/assets/stylesheets/advertising_tags.css.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the advertising_tags controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/controllers/advertising_tags_controller.rb
+++ b/app/controllers/advertising_tags_controller.rb
@@ -1,0 +1,61 @@
+class AdvertisingTagsController < ApplicationController
+  before_filter :load_resource, except: [:index, :new, :create]
+
+  def index
+    authorize AdvertisingTag, :index?
+    @tags = AdvertisingTag.all.order(:name)
+  end
+
+  def show
+    authorize @tag, :show?
+  end
+
+  def new
+    authorize AdvertisingTag, :create?
+    @tag = AdvertisingTag.new
+  end
+
+  def create
+    authorize AdvertisingTag, :create?
+    @tag = AdvertisingTag.new(tag_params)
+    if @tag.save
+      flash[:notice] = 'Advertising Tag was successfully created.'
+      redirect_to @tag
+    else
+      render :new
+    end
+  end
+
+  def edit
+    redirect_to action: :index unless user_can? :edit?, @tag
+    @title = "Editing Tag #{@tag.name}"
+  end
+
+  def update
+    redirect_to action: :index unless user_can? :edit?, @tag
+    if @tag.update_attributes(tag_params)
+      flash[:notice] = 'Advertising Tag was successfully updated.'
+      redirect_to @tag
+    else
+      render :edit
+    end
+  end
+
+  def destroy
+    authorize @tag, :destroy?
+    @tag.destroy
+    redirect_to advertising_tags_path
+  end
+
+private
+  def tag_params
+    params.require(:advertising_tag).permit(
+      :name, :funnel_name, :tracking_code
+    )
+  end
+
+  def load_resource
+    @tag = AdvertisingTag.find_by_id(params[:id])
+  end
+
+end

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -55,7 +55,9 @@ class EventsController < ApplicationController
   end
 
   def destroy
-    redirect_to action: :index unless user_can? :destory?, @event
+    redirect_to action: :index unless user_can? :destroy?, @event
+    @event.destroy
+    redirect_to events_path
   end
 
 private

--- a/app/controllers/index_controller.rb
+++ b/app/controllers/index_controller.rb
@@ -5,6 +5,15 @@ class IndexController < ApplicationController
 		@page = ContentPage.where(:home => true).first
 	end	
 
+  def start_tracking
+    tag = AdvertisingTag.where(funnel_name: params[:id]).first
+    if tag.present?
+      cookies[:advertising_tag_id] = {value: tag.id, expires: 1.month.from_now }
+      session[:advertising_tag_id] = tag.id
+    end
+    redirect_to root_path
+  end
+
 	def set_con_mode
 		SiteSettings.con_mode = params[:enable] == "true"
 		redirect_to admin_path

--- a/app/controllers/store_controller.rb
+++ b/app/controllers/store_controller.rb
@@ -157,6 +157,10 @@ class StoreController < ApplicationController
 				else
 					 ticket.user_id = @store_user.id					
 				end
+				advertising_tag_id = session[:advertising_tag_id] || cookies[:advertising_tag_id]
+				if advertising_tag_id.present?
+					ticket.advertising_tag = AdvertisingTag.where(id: advertising_tag_id).first
+				end
 				ticket.save
 			end
 
@@ -166,6 +170,10 @@ class StoreController < ApplicationController
 					 ticket.user_id = current_user.id
 				else
 					 ticket.user_id = @store_user.id					
+				end
+				advertising_tag_id = session[:advertising_tag_id] || cookies[:advertising_tag_id]
+				if advertising_tag_id.present?
+					ticket.advertising_tag = AdvertisingTag.where(id: advertising_tag_id).first
 				end
 				ticket.save
 			end

--- a/app/controllers/store_controller.rb
+++ b/app/controllers/store_controller.rb
@@ -154,12 +154,12 @@ class StoreController < ApplicationController
 				ticket = UserOrderTicket.new(:ticket_type_id => ticket_id, :user_order_id => order.id)
 				if @store_user == nil
 					 ticket.user_id = current_user.id
+					 advertising_tag_id = session[:advertising_tag_id] || cookies[:advertising_tag_id]
+						if advertising_tag_id.present?
+							ticket.advertising_tag = AdvertisingTag.where(id: advertising_tag_id).first
+						end					 
 				else
 					 ticket.user_id = @store_user.id					
-				end
-				advertising_tag_id = session[:advertising_tag_id] || cookies[:advertising_tag_id]
-				if advertising_tag_id.present?
-					ticket.advertising_tag = AdvertisingTag.where(id: advertising_tag_id).first
 				end
 				ticket.save
 			end
@@ -168,12 +168,12 @@ class StoreController < ApplicationController
 				ticket = UserOrderTicket.new(:ticket_type_id => ticket_id, :user_order_id => order.id, concession: true)
 				if @store_user == nil
 					 ticket.user_id = current_user.id
+						advertising_tag_id = session[:advertising_tag_id] || cookies[:advertising_tag_id]
+						if advertising_tag_id.present?
+							ticket.advertising_tag = AdvertisingTag.where(id: advertising_tag_id).first
+						end
 				else
 					 ticket.user_id = @store_user.id					
-				end
-				advertising_tag_id = session[:advertising_tag_id] || cookies[:advertising_tag_id]
-				if advertising_tag_id.present?
-					ticket.advertising_tag = AdvertisingTag.where(id: advertising_tag_id).first
 				end
 				ticket.save
 			end

--- a/app/helpers/advertising_tags_helper.rb
+++ b/app/helpers/advertising_tags_helper.rb
@@ -1,0 +1,2 @@
+module AdvertisingTagsHelper
+end

--- a/app/models/advertising_tag.rb
+++ b/app/models/advertising_tag.rb
@@ -1,0 +1,2 @@
+class AdvertisingTag < ActiveRecord::Base
+end

--- a/app/models/advertising_tag.rb
+++ b/app/models/advertising_tag.rb
@@ -1,2 +1,3 @@
 class AdvertisingTag < ActiveRecord::Base
+  has_many :user_order_tickets
 end

--- a/app/models/advertising_tag.rb
+++ b/app/models/advertising_tag.rb
@@ -1,3 +1,7 @@
 class AdvertisingTag < ActiveRecord::Base
   has_many :user_order_tickets
+
+  def tickets
+    user_order_tickets
+  end
 end

--- a/app/models/user_order_ticket.rb
+++ b/app/models/user_order_ticket.rb
@@ -2,6 +2,7 @@ class UserOrderTicket < ActiveRecord::Base
 	belongs_to :user
 	belongs_to :ticket_type
 	belongs_to :user_order
+	belongs_to :advertising_tag
 	has_many :user_order_ticket_transfers
 
 	scope :paid, lambda {

--- a/app/policies/advertising_tag_policy.rb
+++ b/app/policies/advertising_tag_policy.rb
@@ -1,0 +1,28 @@
+class AdvertisingTagPolicy < BasePolicy
+  attr_reader :user, :object
+
+  def initialize(user, object = nil)
+    @user = user
+    @object = object
+  end
+
+  def index?
+    committee_or_admin
+  end
+
+  def show?
+    committee_or_admin?
+  end
+
+  def create?
+    admin?
+  end
+
+  def edit?
+    admin?
+  end
+
+  def destroy?
+    admin?
+  end
+end

--- a/app/policies/route_policy.rb
+++ b/app/policies/route_policy.rb
@@ -52,7 +52,7 @@ class RoutePolicy
       member_details: [:edit_my, :update, :create]
     },
     guest: {
-      index: [:index],
+      index: [:index, :track],
       panel_suggestions: [:index, :show, :new, :create],
       award_nomination: [:index, :show, :new, :create, :edit, :update, :show]
     }

--- a/app/policies/route_policy.rb
+++ b/app/policies/route_policy.rb
@@ -52,7 +52,7 @@ class RoutePolicy
       member_details: [:edit_my, :update, :create]
     },
     guest: {
-      index: [:index, :track],
+      index: [:index, :start_tracking],
       panel_suggestions: [:index, :show, :new, :create],
       award_nomination: [:index, :show, :new, :create, :edit, :update, :show]
     }

--- a/app/views/advertising_tags/_form.haml
+++ b/app/views/advertising_tags/_form.haml
@@ -1,0 +1,26 @@
+- if @tag.errors.any?
+  %div{id: "error_explanation"}
+    %h2
+      = pluralize(@tag.errors.count, "error")
+      prohibited this tag from being saved:
+    %ul
+      - @tag.errors.full_messages.each do |msg|
+        %li= msg
+
+= form_for(@tag) do |f|
+  %p
+    = f.label :name, "Name"
+    = f.text_field :name
+
+  %p
+    = f.label :funnel_name, "Funnel Name"
+    = f.text_field :funnel_name, data: {field_name: :name}, class: :shorten_field
+
+  %p
+    = f.label :tracking_code, "Tracking Code"
+    = f.text_area :tracking_code
+
+  - if @tag.new_record?
+    = f.submit("Create")
+  - else
+    = f.submit("Save")

--- a/app/views/advertising_tags/edit.haml
+++ b/app/views/advertising_tags/edit.haml
@@ -1,0 +1,5 @@
+%h1= "Editing #{@tag.name}"
+
+= render partial: 'form'
+
+= link_to "Tags", advertising_tags_path

--- a/app/views/advertising_tags/index.haml
+++ b/app/views/advertising_tags/index.haml
@@ -5,6 +5,7 @@
     %th Name
     %th Funnel Name
     %th Tracking Code
+    %th Sold Tickets
     %th Actions
 
   - @tags.each do |tag|
@@ -12,6 +13,7 @@
       %td= tag.name
       %td= tag.funnel_name
       %td= tag.tracking_code
+      %td= tag.tickets.count
       %td
         = link_to "Show", tag
         - if user_can? :edit, tag

--- a/app/views/advertising_tags/index.haml
+++ b/app/views/advertising_tags/index.haml
@@ -1,0 +1,22 @@
+%h1 Listing Advertising Tags
+
+%table
+  %tr
+    %th Name
+    %th Funnel Name
+    %th Tracking Code
+    %th Actions
+
+  - @tags.each do |tag|
+    %tr
+      %td= tag.name
+      %td= tag.funnel_name
+      %td= tag.tracking_code
+      %td
+        = link_to "Show", tag
+        - if user_can? :edit, tag
+          = link_to "Edit", edit_advertising_tag_path(tag)
+        - if user_can? :delete, tag
+          = link_to "Delete", tag, confirm: "Are you sure?", method: :delete
+
+= link_to "Add New Advertising Tag", new_advertising_tag_path

--- a/app/views/advertising_tags/new.haml
+++ b/app/views/advertising_tags/new.haml
@@ -1,0 +1,5 @@
+%h1 New Advertising Tag
+
+= render partial: 'form'
+
+= link_to "Tags", advertising_tags_path

--- a/app/views/advertising_tags/show.haml
+++ b/app/views/advertising_tags/show.haml
@@ -8,6 +8,10 @@
   Code:
   = @tag.tracking_code
 
+%p 
+  Sold Tickets:
+  = @tag.tickets.count
+
 %p
   = link_to "Edit", edit_advertising_tag_path(@tag)
   |

--- a/app/views/advertising_tags/show.haml
+++ b/app/views/advertising_tags/show.haml
@@ -1,0 +1,17 @@
+%h1=@tag.name
+
+%p
+  Funnel Url: 
+  = link_to "TBD", "TBD"
+
+%p 
+  Code:
+  = @tag.tracking_code
+
+%p
+  = link_to "Edit", edit_advertising_tag_path(@tag)
+  |
+  - if user_can? :destroy, @tag
+    = link_to "Destroy", @tag, confirm: "Are you sure?", method: :delete
+    |
+  = link_to "List All", advertising_tags_path

--- a/app/views/advertising_tags/show.haml
+++ b/app/views/advertising_tags/show.haml
@@ -2,7 +2,7 @@
 
 %p
   Funnel Url: 
-  = link_to "TBD", "TBD"
+  = link_to tracking_path(id: @tag.funnel_name, only_path: false), tracking_path(id: @tag.funnel_name, only_path: false)
 
 %p 
   Code:

--- a/app/views/index/admin.html.haml
+++ b/app/views/index/admin.html.haml
@@ -21,6 +21,7 @@
 		%li= link_to "Merchandise Administration", merchandise_types_path
 		%li= link_to "Merchandise Set Administration", merchandise_sets_path
 		%li= link_to "Merchandise Option Set Administration", merchandise_option_sets_path
+		%li= link_to "Advertising Tags", advertising_tags_path
 		- if user_can_visit? :index, :set_con_mode
 			- if SiteSettings.con_mode
 				%li= link_to "Disable Con Mode", set_con_mode_path(enable: false)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -80,6 +80,8 @@ DoomCon::Application.routes.draw do
     post 'remail', :on => :member
   end
 
+  resources :advertising_tags
+
   # Sample of regular route:
   #   match 'products/:id' => 'catalog#view'
   # Keep in mind you can assign values other than :controller and :action

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -122,5 +122,7 @@ DoomCon::Application.routes.draw do
   match '/admin' => "index#admin", as: "admin", via: [:get]
   match '/admin/set_con_mode' => "index#set_con_mode", as: "set_con_mode", via: [:get]
 
+  match '/track/:id' => "index#start_tracking", via: [:get], as: "tracking"
+
   root :to => "index#index"
 end

--- a/db/migrate/20150218132707_create_advertising_tags.rb
+++ b/db/migrate/20150218132707_create_advertising_tags.rb
@@ -1,0 +1,10 @@
+class CreateAdvertisingTags < ActiveRecord::Migration
+  def change
+    create_table :advertising_tags do |t|
+      t.string :name, null: false
+      t.string :funnel_name, null: false
+      t.string :tracking_code
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20150218141042_add_tag_to_ticket_sale.rb
+++ b/db/migrate/20150218141042_add_tag_to_ticket_sale.rb
@@ -1,0 +1,7 @@
+class AddTagToTicketSale < ActiveRecord::Migration
+  def change
+    change_table :user_order_tickets do |t|
+      t.integer :advertising_tag_id
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150218132707) do
+ActiveRecord::Schema.define(version: 20150218141042) do
 
   create_table "advertising_tags", force: true do |t|
     t.string   "name",          null: false
@@ -326,8 +326,9 @@ ActiveRecord::Schema.define(version: 20150218132707) do
     t.datetime "updated_at"
     t.datetime "card_issued"
     t.datetime "arrived"
-    t.boolean  "concession",     default: false, null: false
+    t.boolean  "concession",         default: false, null: false
     t.datetime "redeemed_at"
+    t.integer  "advertising_tag_id"
   end
 
   create_table "user_orders", force: true do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,15 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20140419055245) do
+ActiveRecord::Schema.define(version: 20150218132707) do
+
+  create_table "advertising_tags", force: true do |t|
+    t.string   "name",          null: false
+    t.string   "funnel_name",   null: false
+    t.string   "tracking_code"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+  end
 
   create_table "award_categories", force: true do |t|
     t.string   "name",        null: false

--- a/test/controllers/advertising_tags_controller_test.rb
+++ b/test/controllers/advertising_tags_controller_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class AdvertisingTagsControllerTest < ActionController::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/fixtures/advertising_tags.yml
+++ b/test/fixtures/advertising_tags.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined.  If you add columns to the
+# model remove the '{}' from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+#  column: value

--- a/test/helpers/advertising_tags_helper_test.rb
+++ b/test/helpers/advertising_tags_helper_test.rb
@@ -1,0 +1,4 @@
+require 'test_helper'
+
+class AdvertisingTagsHelperTest < ActionView::TestCase
+end

--- a/test/models/advertising_tag_test.rb
+++ b/test/models/advertising_tag_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class AdvertisingTagTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
This adds inbound advertising tracking. 
1. Add one or more Advertising Tags (accessible from Store Administration - 2nd last option)
2. Each Advertising Tag will have a "funnel URL" - send people to the site via that URL
3. When one or more tickets are purchased, they are marked as coming from that funnel url (unless cookies are deleted)
